### PR TITLE
Use attribute lookup on Image instead of method call

### DIFF
--- a/vendor/three/blender-exporter/addons/io_three/exporter/api/image.py
+++ b/vendor/three/blender-exporter/addons/io_three/exporter/api/image.py
@@ -49,4 +49,4 @@ def file_path(image):
 
     """
     logger.debug("image.file_path(%s)", image)
-    return os.path.normpath(image.filepath_from_user())
+    return os.path.normpath(image.filepath)


### PR DESCRIPTION
The `filepath_from_user` method call on the Image type in the exporter
appears to depend on a specific version of the Blender API, which
doesn't seem to be available in Blender <2.70 (at least in our
production use of this, it isn't).

What seems to work is the `filepath` attribute --
https://www.blender.org/api/blender_python_api_2_69_release/bpy.types.Image.html#bpy.types.Image.filepath
-- which is forward compatible as well.